### PR TITLE
Fix SDK initialization in MainPage.xaml.cs

### DIFF
--- a/AppExampleMaui/MainPage.xaml.cs
+++ b/AppExampleMaui/MainPage.xaml.cs
@@ -7,19 +7,30 @@ public partial class MainPage : ContentPage
 
 	public MainPage()
 	{
-		
 		InitializeComponent();
-        //Insider.Instance.Init((Android.App.Application?)Android.App.Application.Context.ApplicationContext, "caaqui");
 
-		if (Insider.Instance.IsSDKInitialized)
-		{
-			Insider.Instance.SetPushToken("teste");
+#if ANDROID
+        try
+        {
+            Insider.Instance.Init((Android.App.Application?)Android.App.Application.Context.ApplicationContext, "caaqui");
+
+            if (Insider.Instance.IsSDKInitialized)
+            {
+                Insider.Instance.SetPushToken("teste");
+            }
+            else
+            {
+                CounterBtn.Text = $"SDK Insider não iniciou.";
+            }
         }
-		else
-		{
-            CounterBtn.Text = $"SDK Insider não iniciou.";
+        catch (Exception ex)
+        {
+            // Log the exception details
+            Console.WriteLine($"SDK Initialization Error: {ex.Message}");
+            // Display a user-friendly error message
+            CounterBtn.Text = $"SDK Initialization failed.";
         }
-		
+#endif
 	}
 
 	private void OnCounterClicked(object sender, EventArgs e)
@@ -34,5 +45,3 @@ public partial class MainPage : ContentPage
 		SemanticScreenReader.Announce(CounterBtn.Text);
 	}
 }
-
-


### PR DESCRIPTION
Uncomment the `Init` method for the Insider SDK and add platform-specific checks in `AppExampleMaui/MainPage.xaml.cs`.

* **Platform-Specific Checks**: Add `#if ANDROID` preprocessor directive to ensure the `Init` method runs only on Android.
* **Error Handling**: Wrap the SDK initialization code in a try-catch block to handle errors, log exception details, and display a user-friendly error message.
* **SDK Initialization**: Call the `SetPushToken` method after confirming the SDK is initialized by checking `Insider.Instance.IsSDKInitialized`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cristianoaredes/InsiderBindingLibrary/pull/1?shareId=c407a9c7-c866-469f-8e67-96157e2fa1fc).