### PR TITLE
Verify SDK setup for Insider

### DIFF
--- a/AppExampleMaui/MainPage.xaml.cs
+++ b/AppExampleMaui/MainPage.xaml.cs
@@ -9,7 +9,7 @@ public partial class MainPage : ContentPage
 	{
 		
 		InitializeComponent();
-        //Insider.Instance.Init((Android.App.Application?)Android.App.Application.Context.ApplicationContext, "caaqui");
+        Insider.Instance.Init((Android.App.Application?)Android.App.Application.Context.ApplicationContext, "caaqui");
 
 		if (Insider.Instance.IsSDKInitialized)
 		{
@@ -34,5 +34,4 @@ public partial class MainPage : ContentPage
 		SemanticScreenReader.Announce(CounterBtn.Text);
 	}
 }
-
 

--- a/AppExampleMaui/Platforms/MacCatalyst/Info.plist
+++ b/AppExampleMaui/Platforms/MacCatalyst/Info.plist
@@ -34,5 +34,15 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/appicon.appiconset</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/AppExampleMaui/Platforms/Tizen/tizen-manifest.xml
+++ b/AppExampleMaui/Platforms/Tizen/tizen-manifest.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <manifest package="maui-application-id-placeholder" version="0.0.0" api-version="8" xmlns="http://tizen.org/ns/packages">
   <profile name="common" />
   <ui-application appid="maui-application-id-placeholder" exec="AppExampleMaui.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
@@ -9,6 +9,8 @@
   <shortcut-list />
   <privileges>
     <privilege>http://tizen.org/privilege/internet</privilege>
+    <privilege>http://tizen.org/privilege/network.get</privilege>
+    <privilege>http://tizen.org/privilege/network.set</privilege>
   </privileges> 
   <dependencies />
   <provides-appdefined-privileges />

--- a/AppExampleMaui/Platforms/iOS/Info.plist
+++ b/AppExampleMaui/Platforms/iOS/Info.plist
@@ -28,5 +28,15 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/appicon.appiconset</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Initialize the Insider SDK and add necessary configurations for iOS, MacCatalyst, and Tizen platforms.

* Uncomment the line `Insider.Instance.Init` in `AppExampleMaui/MainPage.xaml.cs` to initialize the SDK.
* Add necessary configurations for the Insider SDK in `AppExampleMaui/Platforms/iOS/Info.plist`.
* Add necessary configurations for the Insider SDK in `AppExampleMaui/Platforms/MacCatalyst/Info.plist`.
* Add necessary configurations for the Insider SDK in `AppExampleMaui/Platforms/Tizen/tizen-manifest.xml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cristianoaredes/InsiderBindingLibrary/pull/2?shareId=025d2c72-e130-472f-acd9-e1068a896e4d).