### PR TITLE
Update Insider library reference

### DIFF
--- a/AppExampleMaui/MainPage.xaml.cs
+++ b/AppExampleMaui/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Com.Useinsider.Insider;
+﻿using InsiderBindingLibrary;
 using Serilog;
 using System.Threading.Tasks;
 

--- a/AppExampleMaui/Platforms/Android/MainActivity.cs
+++ b/AppExampleMaui/Platforms/Android/MainActivity.cs
@@ -1,7 +1,7 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using Com.Useinsider.Insider;
+using InsiderBindingLibrary;
 
 namespace AppExampleMaui;
 

--- a/AppExampleMaui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/AppExampleMaui/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,5 +1,5 @@
 ﻿using Foundation;
-using Com.Useinsider.Insider;
+using InsiderBindingLibrary;
 
 namespace AppExampleMaui;
 

--- a/AppExampleMaui/Platforms/Tizen/Main.cs
+++ b/AppExampleMaui/Platforms/Tizen/Main.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
-using Com.Useinsider.Insider;
+using InsiderBindingLibrary;
 
 namespace AppExampleMaui;
 

--- a/AppExampleMaui/Platforms/Windows/App.xaml.cs
+++ b/AppExampleMaui/Platforms/Windows/App.xaml.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.UI.Xaml;
-using Com.Useinsider.Insider;
+using InsiderBindingLibrary;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.

--- a/AppExampleMaui/Platforms/iOS/AppDelegate.cs
+++ b/AppExampleMaui/Platforms/iOS/AppDelegate.cs
@@ -1,5 +1,5 @@
 ﻿using Foundation;
-using Com.Useinsider.Insider;
+using InsiderBindingLibrary;
 
 namespace AppExampleMaui;
 


### PR DESCRIPTION
Update the project to reference the `InsiderBindingLibrary` project instead of the `Com.Useinsider.Insider` library.

* **MainPage.xaml.cs**
  - Update the `using` directive to reference the `InsiderBindingLibrary` project.

* **Platforms/Android/MainActivity.cs**
  - Update the `using` directive to reference the `InsiderBindingLibrary` project.

* **Platforms/iOS/AppDelegate.cs**
  - Update the `using` directive to reference the `InsiderBindingLibrary` project.

* **Platforms/MacCatalyst/AppDelegate.cs**
  - Update the `using` directive to reference the `InsiderBindingLibrary` project.

* **Platforms/Tizen/Main.cs**
  - Update the `using` directive to reference the `InsiderBindingLibrary` project.

* **Platforms/Windows/App.xaml.cs**
  - Update the `using` directive to reference the `InsiderBindingLibrary` project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cristianoaredes/InsiderBindingLibrary/pull/8?shareId=7ace2103-146e-4801-8638-4829cfba317a).